### PR TITLE
CMake: resolve deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 PROJECT(uqmi C)
 


### PR DESCRIPTION
Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.