### PR TITLE
Add UCS-2 SMS sending and qmiproxy support

### DIFF
--- a/common/mbim.c
+++ b/common/mbim.c
@@ -27,6 +27,52 @@
 
 static const uint8_t qmiuuid[16] = { 0xd1, 0xa3, 0x0b, 0xc2, 0xf9, 0x7a, 0x6e, 0x43,
 				     0xbf, 0x65, 0xc7, 0xe2, 0x4f, 0xb0, 0xf0, 0xd3 };
+#define LIBQMI_QMI_PROXY 1
+#ifdef LIBQMI_QMI_PROXY
+static const uint8_t proxyuuid[16] =  { 0x83, 0x8c, 0xf7, 0xfb, 0x8d, 0x0d, 0x4d, 0x7f,
+					0x87, 0x1e, 0xd7, 0x1d, 0xbe, 0xfb, 0xb3, 0x9b };
+
+#define MBIM_CMD_PROXY_CONTROL_CONFIGURATION	1
+
+struct mbim_proxy_control {
+	uint32_t dev_off;
+	uint32_t dev_len;
+	uint32_t timeout;
+} __attribute__((packed));
+
+int mbim_proxy_cmd(struct mbim_command_message *msg, const char *path)
+{
+	struct mbim_proxy_control *p = (void *)(msg + 1);
+	int i, pathlen = strlen(path);
+	char *c = (void *)(p + 1);;
+
+	msg->header.type = cpu_to_le32(MBIM_MESSAGE_TYPE_COMMAND);
+	msg->header.length = cpu_to_le32(sizeof(*msg) + 2 * pathlen + sizeof(struct mbim_proxy_control));
+	msg->header.transaction_id = cpu_to_le32(1);
+	msg->fragment_header.total = cpu_to_le32(1);
+	msg->fragment_header.current = 0;
+	memcpy(msg->service_id, proxyuuid, 16);
+	msg->command_id = cpu_to_le32(MBIM_CMD_PROXY_CONTROL_CONFIGURATION);
+	msg->command_type = cpu_to_le32(MBIM_MESSAGE_COMMAND_TYPE_SET);
+	msg->buffer_length = cpu_to_le32(2 * pathlen + sizeof(struct mbim_proxy_control));
+
+	p->timeout = cpu_to_le32(5); // FIXME: hard coded timeout
+	p->dev_off = cpu_to_le32(sizeof(struct mbim_proxy_control));
+	p->dev_len = cpu_to_le32(2 * pathlen);
+	memset(c, 0, 2 * pathlen);
+	for (i = 0; i < pathlen; i++)
+		c[i * 2] = path[i];
+	return sizeof(struct mbim_command_message) + sizeof(struct mbim_proxy_control) + 2 * pathlen;
+}
+
+bool is_mbim_proxy(struct mbim_command_message *msg)
+{
+	return msg->header.type == cpu_to_le32(MBIM_MESSAGE_TYPE_COMMAND_DONE) &&
+		msg->command_id == cpu_to_le32(MBIM_CMD_PROXY_CONTROL_CONFIGURATION) &&
+		!msg->command_type &&	/* actually 'status' here */
+		!memcmp(msg->service_id, proxyuuid, 16);
+}
+#endif
 
 bool is_mbim_qmi(struct mbim_command_message *msg)
 {

--- a/common/mbim.h
+++ b/common/mbim.h
@@ -50,6 +50,8 @@ struct mbim_command_message {
 	uint32_t buffer_length;
 } __packed;
 
+int mbim_proxy_cmd(struct mbim_command_message *msg, const char *path);
+bool is_mbim_proxy(struct mbim_command_message *msg);
 bool is_mbim_qmi(struct mbim_command_message *msg);
 void mbim_qmi_cmd(struct mbim_command_message *msg, int len, uint16_t tid);
 

--- a/uqmi/CMakeLists.txt
+++ b/uqmi/CMakeLists.txt
@@ -5,8 +5,10 @@ SET(UQMI uqmi.c dev.c commands.c ${SOURCES})
 ADD_EXECUTABLE(uqmi ${UQMI})
 ADD_DEPENDENCIES(uqmi gen-headers gen-errors)
 
-TARGET_LINK_LIBRARIES(uqmi ${LIBS} common qmigen)
-TARGET_INCLUDE_DIRECTORIES(uqmi PRIVATE ${ubox_include_dir} ${blobmsg_json_include_dir} ${json_include_dir} ${CMAKE_SOURCE_DIR})
+FIND_PACKAGE(Iconv)
+
+TARGET_LINK_LIBRARIES(uqmi ${LIBS} ${Iconv_LIBRARIES} common qmigen)
+TARGET_INCLUDE_DIRECTORIES(uqmi PRIVATE ${ubox_include_dir} ${blobmsg_json_include_dir} ${json_include_dir} ${Iconv_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
 
 INSTALL(TARGETS uqmi
 	RUNTIME DESTINATION sbin

--- a/uqmi/uqmi.h
+++ b/uqmi/uqmi.h
@@ -107,6 +107,7 @@ struct qmi_request {
 
 extern bool cancel_all_requests;
 int qmi_device_open(struct qmi_dev *qmi, const char *path);
+int qmi_device_proxy_open(struct qmi_dev *qmi, const char *path);
 void qmi_device_close(struct qmi_dev *qmi);
 
 int qmi_request_start(struct qmi_dev *qmi, struct qmi_request *req, request_cb cb);


### PR DESCRIPTION
This is an attempt to solve the issue discussed in https://forum.openwrt.org/t/sending-sms-from-cli-containing-cyrillic-characters/231232/18

The qmiproxy support makes it much easier for me to test and use uqmi, since most of my modem devices usually are handled by ModemManager.  Thought I could throw it in as well, in case someone else finds it useful.  You'll obviously need to install libqmi to use it. Or libmbim if the modem is running in MBIM mode. But you'll already have those if you need this.