### PR TITLE
Add `--uim-read-transparent` command

### DIFF
--- a/uqmi/commands-uim.c
+++ b/uqmi/commands-uim.c
@@ -26,6 +26,46 @@ static int channel_id = -1;
 static uint8_t aid[16];
 static uint8_t apdu[1024];
 
+static int
+uqmi_uim_file_path_parse(char *arg, uint16_t *file_id, uint8_t *file_path, unsigned int *file_path_n)
+{
+	char *s, *ptr, *token, *err;
+	unsigned int max_path_n = *file_path_n;
+	unsigned long value;
+	int i;
+
+	for (i = 0, s = arg; ; i++, s = NULL) {
+		token = strtok_r(s, ",", &ptr);
+		if (token == NULL) {
+			*file_path_n = (i - 1) * 2;
+			break;
+		}
+
+		if (i > max_path_n / 2) {
+			// Path is too long
+			uqmi_add_error("Invalid PATH argument");
+			return -1;
+		}
+
+		if (i > 0) {
+			file_path[(i - 1) * 2] = *file_id & 0xFF;
+			file_path[(i - 1) * 2 + 1] = (*file_id >> 8) & 0xFF;
+		}
+
+		value = strtoul(token, &err, 0);
+
+		if ((err && *err) || value < 0 || value > 0xFFFF) {
+			// Invalid path part value
+			uqmi_add_error("Invalid PATH argument");
+			return -1;
+		}
+
+		*file_id = value & 0xFFFF;
+	}
+
+	return 0;
+}
+
 #define cmd_uim_verify_pin1_cb no_cb
 static enum qmi_cmd_result
 cmd_uim_verify_pin1_prepare(struct qmi_dev *qmi, struct qmi_request *req, struct qmi_msg *msg, char *arg)
@@ -319,5 +359,58 @@ cmd_uim_send_apdu_prepare(struct qmi_dev *qmi, struct qmi_request *req, struct q
 	}
 
 	qmi_set_uim_send_apdu_request(msg, &data);
+	return QMI_CMD_REQUEST;
+}
+
+static void cmd_uim_read_transparent_cb(struct qmi_dev *qmi, struct qmi_request *req, struct qmi_msg *msg)
+{
+	struct qmi_uim_read_transparent_response res;
+	void *c, *a;
+
+	qmi_parse_uim_read_transparent_response(msg, &res);
+
+	c = blobmsg_open_table(&status, NULL);
+	if (res.data.card_result) {
+		blobmsg_add_u32(&status, "sw1", res.data.card_result.sw1);
+		blobmsg_add_u32(&status, "sw2", res.data.card_result.sw2);
+	}
+	a = blobmsg_open_array(&status, "read");
+	for (int i = 0; i < res.data.read_result_n; i++) {
+		blobmsg_add_u32(&status, NULL, res.data.read_result[i]);
+	}
+	blobmsg_close_array(&status, a);
+	blobmsg_close_table(&status, c);
+}
+
+static enum qmi_cmd_result
+cmd_uim_read_transparent_prepare(struct qmi_dev *qmi, struct qmi_request *req, struct qmi_msg *msg, char *arg)
+{
+	uint16_t file_id = 0;
+	unsigned int file_path_n = 10;
+	uint8_t file_path[file_path_n];
+
+	memset(file_path, 0, file_path_n * sizeof(uint8_t));
+
+	if (uqmi_uim_file_path_parse(arg, &file_id, file_path, &file_path_n) < 0) {
+		return QMI_CMD_EXIT;
+	}
+
+	struct qmi_uim_read_transparent_request data = {
+		QMI_INIT_SEQUENCE(session,
+			.session_type = QMI_UIM_SESSION_TYPE_PRIMARY_GW_PROVISIONING,
+			.application_identifier_n = 0
+		),
+		QMI_INIT_SEQUENCE(file,
+			.file_id = file_id,
+			.file_path_n = file_path_n,
+			.file_path = file_path
+		),
+		QMI_INIT_SEQUENCE(read_information,
+			.offset = 0,
+			.length = 0
+		)
+	};
+
+	qmi_set_uim_read_transparent_request(msg, &data);
 	return QMI_CMD_REQUEST;
 }

--- a/uqmi/commands-uim.c
+++ b/uqmi/commands-uim.c
@@ -370,7 +370,7 @@ static void cmd_uim_read_transparent_cb(struct qmi_dev *qmi, struct qmi_request 
 	qmi_parse_uim_read_transparent_response(msg, &res);
 
 	c = blobmsg_open_table(&status, NULL);
-	if (res.data.card_result) {
+	if (res.set.card_result) {
 		blobmsg_add_u32(&status, "sw1", res.data.card_result.sw1);
 		blobmsg_add_u32(&status, "sw2", res.data.card_result.sw2);
 	}

--- a/uqmi/commands-uim.h
+++ b/uqmi/commands-uim.h
@@ -29,7 +29,8 @@
 	__uqmi_command(uim_channel_id, uim-channel-id, required, CMD_TYPE_OPTION), \
 	__uqmi_command(uim_open_logical_channel, uim-channel-open, required, QMI_SERVICE_UIM), \
 	__uqmi_command(uim_close_logical_channel, uim-channel-close, no, QMI_SERVICE_UIM), \
-	__uqmi_command(uim_send_apdu, uim-apdu-send, required, QMI_SERVICE_UIM) \
+	__uqmi_command(uim_send_apdu, uim-apdu-send, required, QMI_SERVICE_UIM), \
+	__uqmi_command(uim_read_transparent, uim-read-transparent, required, QMI_SERVICE_UIM) \
 
 
 #define uim_helptext \
@@ -48,4 +49,5 @@
 		"  --uim-apdu-send <cmd>:            Send APDU command to ICC\n" \
 		"    --uim-slot:                     SIM slot [1-2]\n" \
 		"    --uim-channel-id:               Channel-id\n" \
+		"  --uim-read-transparent <PATH>     Read a transparent file from PATH\n" \
 


### PR DESCRIPTION
This PR adds `--uim-read-transparent` command which allows reading transparent files from the SIM card. For example, it can be used to read card's ICCID:
```sh
uqmi -d /dev/wdm-cdc0 --uim-read-transparent=0x3F00,0x2FE2
```

Which produces result like this (I've randomized output bytes as I don't want to reveal ICCID of my card):
```json
{
        "sw1": 144,
        "sw2": 0,
        "read": [
                152,
                34,
                51,
                68,
                85,
                102,
                119,
                136,
                41,
                246
        ]
}
```

The `read` array contains values of read_result array returned by the card. The data format depends on specific file. For ICCID I've confirmed that the data returned is correct and I get the same ICCID number that I get with `AT+ICCID` AT command.